### PR TITLE
refactor: remove `semver` from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12383,7 +12383,8 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "send": {
       "version": "0.17.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "rxjs": ">=6.0.0",
     "webpack": ">=4.6.0",
     "webpack-merge": "^4.2.1",
-    "semver": ">=6.2.0",
     "single-spa": ">=4.0.0"
   },
   "devDependencies": {
@@ -65,7 +64,6 @@
     "webpack": "^4.29.6"
   },
   "dependencies": {
-    "semver": "^6.2.0",
     "single-spa": ">= 5.1.1"
   }
 }

--- a/src/schematics/ng-add/index.ts
+++ b/src/schematics/ng-add/index.ts
@@ -14,7 +14,6 @@ import {
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { getWorkspace, getWorkspacePath } from '@schematics/angular/utility/config';
 import { normalize, join } from 'path';
-import * as semver from 'semver';
 import { WorkspaceProject, Builders, BrowserBuilderOptions } from '@schematics/angular/utility/workspace-models';
 
 import { Schema as NgAddOptions } from './schema';
@@ -173,6 +172,6 @@ function getClientProject(host: Tree, options: NgAddOptions): { name: string, wo
 }
 
 function atLeastAngular8(): boolean {
-  const angularCoreVersion = require(join(process.cwd(), 'package.json')).dependencies['@angular/core'] || '9';
-  return semver.satisfies(semver.minVersion(angularCoreVersion), '>=8');
+  const { VERSION } = require('@angular/core');
+  return Number(VERSION.major) >= 8;
 }


### PR DESCRIPTION
Joel, this check for Angular has to be removed in the future IMO, because Angular 7 LTS ends on 18 April 2020. We'd want to maintain only stable versions.