### PR TITLE
build(single-spa-angular): move internal functions to `single-spa-angular/internals` package

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
   "rules": {
     "semi": ["error", "always"],
     "indent": "off",
-    "@typescript-eslint/indent": ["error", 2],
+    "@typescript-eslint/indent": false,
     "@typescript-eslint/explicit-function-return-type": false,
     "@typescript-eslint/explicit-member-accessibility": false,
     "@typescript-eslint/no-explicit-any": false,

--- a/src/internals/package.json
+++ b/src/internals/package.json
@@ -1,0 +1,9 @@
+{
+  "ngPackage": {
+    "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "src/index.ts",
+      "flatModuleFile": "single-spa-angular-internals"
+    }
+  }
+}

--- a/src/internals/src/dom.ts
+++ b/src/internals/src/dom.ts
@@ -1,0 +1,65 @@
+import { SingleSpaAngularOpts, DomElementGetter } from './types';
+
+export function removeApplicationFromDOMIfIvyEnabled(opts: SingleSpaAngularOpts, props: any): void {
+  if (ivyEnabled()) {
+    const domElementGetter = chooseDomElementGetter(opts, props);
+    const domElement = getContainerEl(domElementGetter);
+    // View Engine removes all nodes automatically when calling `NgModuleRef.destroy()`,
+    // which calls `ComponentRef.destroy()`.
+    // Basically this will remove `app-root` or any other selector from the container element.
+    while (domElement.firstChild) domElement.removeChild(domElement.firstChild);
+  }
+}
+
+export function getContainerEl(domElementGetter: DomElementGetter): never | HTMLElement {
+  const element = domElementGetter();
+
+  if (!element) {
+    throw Error('domElementGetter did not return a valid dom element');
+  }
+
+  return element;
+}
+
+export function chooseDomElementGetter(opts: SingleSpaAngularOpts, props: any): DomElementGetter {
+  props = props?.customProps ?? props;
+
+  if (props.domElement) {
+    return () => props.domElement;
+  } else if (props.domElementGetter) {
+    return props.domElementGetter;
+  } else if (opts.domElementGetter) {
+    return opts.domElementGetter;
+  } else {
+    return defaultDomElementGetter(props.name);
+  }
+}
+
+function defaultDomElementGetter(name: string): DomElementGetter {
+  return function getDefaultDomElement() {
+    const id = `single-spa-application:${name}`;
+    let domElement: HTMLElement | null = document.getElementById(id);
+
+    if (!domElement) {
+      domElement = document.createElement('div');
+      domElement.id = id;
+      document.body.appendChild(domElement);
+    }
+
+    return domElement;
+  };
+}
+
+function ivyEnabled(): boolean {
+  try {
+    // `ɵivyEnabled` variable is exposed starting from version 8.
+    // We use `require` here except of a single `import { ɵivyEnabled }` because the
+    // developer can use Angular version that doesn't expose it (all versions <8).
+    // The `catch` statement will handle those cases.
+    // eslint-disable-next-line
+    const { ɵivyEnabled } = require('@angular/core');
+    return !!ɵivyEnabled;
+  } catch {
+    return false;
+  }
+}

--- a/src/internals/src/index.ts
+++ b/src/internals/src/index.ts
@@ -1,0 +1,6 @@
+export { SingleSpaAngularOpts, BootstrappedSingleSpaAngularOpts } from './types';
+export {
+  getContainerEl,
+  chooseDomElementGetter,
+  removeApplicationFromDOMIfIvyEnabled,
+} from './dom';

--- a/src/internals/src/types.ts
+++ b/src/internals/src/types.ts
@@ -1,0 +1,21 @@
+import { NgZone, NgModuleRef, Type } from '@angular/core';
+import { AppProps } from 'single-spa';
+
+export type DomElementGetter = () => HTMLElement;
+
+export interface SingleSpaAngularOpts {
+  NgZone: typeof NgZone;
+  bootstrapFunction(props: AppProps): Promise<NgModuleRef<any>>;
+  updateFunction?(props: AppProps): Promise<any>;
+  template: string;
+  Router?: Type<any>;
+  domElementGetter?(): HTMLElement;
+  AnimationEngine?: Type<any>;
+}
+
+export interface BootstrappedSingleSpaAngularOpts extends SingleSpaAngularOpts {
+  bootstrappedNgZone: NgZone;
+  bootstrappedModule: NgModuleRef<any>;
+  routingEventListener: () => void;
+  zoneIdentifier: string;
+}

--- a/src/package.json
+++ b/src/package.json
@@ -31,7 +31,10 @@
     "lib": {
       "umdId": "single-spa-angular",
       "flatModuleFile": "single-spa-angular",
-      "entryFile": "index.ts"
+      "entryFile": "index.ts",
+      "umdModuleIds": {
+        "single-spa-angular/internals": "single-spa-angular-internals"
+      }
     },
     "dest": "../lib"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,10 @@
   "compileOnSave": false,
   "compilerOptions": {
     "baseUrl": "./",
+    "paths": {
+      "single-spa-angular": ["src/index.ts"],
+      "single-spa-angular/internals": ["src/internals/src/index.ts"]
+    },
     "target": "es5",
     "lib": ["es2018", "dom"],
     "moduleResolution": "node",


### PR DESCRIPTION
Internal functions are moved into a separate package. This will be possible to re-use them when implementing additional packages for `@angular/elements` and `renderComponent`.