### PR TITLE
feat: install single-spa dependency in angular schematic

### DIFF
--- a/schematics/ng-add/dependencies.ts
+++ b/schematics/ng-add/dependencies.ts
@@ -2,15 +2,20 @@ import { NodeDependencyType, NodeDependency } from '@schematics/angular/utility/
 
 interface PackageJson {
   version: string;
-  peerDependencies: string[];
-  dependencies: string[];
+  peerDependencies?: {
+    'single-spa': string;
+  };
+  dependencies?: {
+    'single-spa': string;
+  };
 }
 
 const { version, peerDependencies, dependencies }: PackageJson = require('../../package.json');
 
 export function getSingleSpaDependency(): NodeDependency {
-  const singleSpaVersion = peerDependencies['single-spa'] || dependencies['single-spa'];
-  console.log('single-spa dep version', singleSpaVersion);
+  const singleSpaVersion =
+    peerDependencies?.['single-spa'] || dependencies?.['single-spa'] || 'latest';
+
   return {
     name: 'single-spa',
     version: singleSpaVersion,

--- a/schematics/ng-add/dependencies.ts
+++ b/schematics/ng-add/dependencies.ts
@@ -1,9 +1,28 @@
 import { NodeDependencyType, NodeDependency } from '@schematics/angular/utility/dependencies';
 
+interface PackageJson {
+  version: string;
+  peerDependencies: string[];
+  dependencies: string[];
+}
+
+const { version, peerDependencies, dependencies }: PackageJson = require('../../package.json');
+
+export function getSingleSpaDependency(): NodeDependency {
+  const singleSpaVersion = peerDependencies['single-spa'] || dependencies['single-spa'];
+  console.log('single-spa dep version', singleSpaVersion);
+  return {
+    name: 'single-spa',
+    version: singleSpaVersion,
+    overwrite: true,
+    type: NodeDependencyType.Default,
+  };
+}
+
 export function getSingleSpaAngularDependency(): NodeDependency {
   return {
     name: 'single-spa-angular',
-    version: require('../../package.json').version,
+    version,
     overwrite: false,
     type: NodeDependencyType.Default,
   };

--- a/schematics/ng-add/index.ts
+++ b/schematics/ng-add/index.ts
@@ -25,6 +25,7 @@ import { normalize, join } from 'path';
 import { addScripts } from './add-scripts';
 import { Schema as NgAddOptions } from './schema';
 import {
+  getSingleSpaDependency,
   getSingleSpaAngularDependency,
   getAngularBuildersCustomWebpackDependency,
 } from './dependencies';
@@ -46,6 +47,7 @@ export default function (options: NgAddOptions): Rule {
 
 export function addDependencies(): Rule {
   const dependencies: NodeDependency[] = [
+    getSingleSpaDependency(),
     getSingleSpaAngularDependency(),
     getAngularBuildersCustomWebpackDependency(),
   ];

--- a/schematics/ng-add/tests/index.spec.ts
+++ b/schematics/ng-add/tests/index.spec.ts
@@ -46,11 +46,12 @@ describe('ng-add', () => {
     expect(tree.files).toBeDefined();
   });
 
-  test('should add single-spa to dependencies', async () => {
+  test('should add single-spa and single-spa-angular to dependencies', async () => {
     const tree = await testRunner
       .runSchematicAsync<NgAddOptions>('ng-add', {}, defaultAppTree)
       .toPromise();
     const packageJSON = JSON.parse(getFileContent(tree, '/package.json'));
+    expect(packageJSON.dependencies['single-spa']).toBeDefined();
     expect(packageJSON.dependencies['single-spa-angular']).toBeDefined();
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Single-spa is a peerDependency so it is not installed when the schematic is being run, which means that users have to manually install it after a project is created with create-single-spa. Its annoying at best, frustrating at worst because users don't understand why it doesn't work right after creating.

Issue Number: https://github.com/single-spa/create-single-spa/issues/106 

this issue is logged with create-single-spa but I believe it'd be better to implement here in case someone reruns the schematic or doesn't use create-single-spa. 

## What is the new behavior?

As part of the schematic, single-spa is added to the package.json dependencies.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
[x] Possibly 
```

## Other information

I marked this as a breaking change because re-running this schematic may modify the version of single-spa in the target project's package.json. This may not actually be a breaking change or a big deal but I'd like to ensure that it seems ok since I don't have much experience with Angular.