### PR TITLE
ci: setup actions for `3.x`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "@typescript-eslint/indent": ["error", 2],
     "@typescript-eslint/explicit-function-return-type": false,
     "@typescript-eslint/explicit-member-accessibility": false,
-    "@typescript-eslint/no-explicit-any": false
+    "@typescript-eslint/no-explicit-any": false,
+    "@typescript-eslint/no-non-null-assertion": false
   }
 }

--- a/.github/workflows/single-spa-angular.yml
+++ b/.github/workflows/single-spa-angular.yml
@@ -1,0 +1,43 @@
+name: single-spa-angular
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        id: npm-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm
+
+      - uses: actions/setup-node@v1
+        with:
+          # Currently used `node-sass` version is not available for Node 12
+          # and `actions/setup-node` provides only LTS version, that means
+          # there is no Node 11.
+          node-version: 10.x
+
+      - name: Install dependencies
+        if: steps.npm-cache.output.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Run Jest
+        run: npm run test

--- a/src/browser-lib/single-spa-angular.ts
+++ b/src/browser-lib/single-spa-angular.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import { AppProps, LifeCycles } from 'single-spa'
+import { AppProps, LifeCycles } from 'single-spa';
 
 import { SingleSpaPlatformLocation } from './extra-providers';
 
@@ -26,7 +26,7 @@ export default function singleSpaAngular(userOpts: SingleSpaAngularOpts): LifeCy
   };
 
   if (typeof opts.bootstrapFunction !== 'function') {
-    throw Error("single-spa-angular must be passed an opts.bootstrapFunction")
+    throw Error("single-spa-angular must be passed an opts.bootstrapFunction");
   }
 
   if (typeof opts.template !== "string") {
@@ -58,15 +58,15 @@ function bootstrap(opts, props) {
     opts.NgZone.isInAngularZone = function() {
       // @ts-ignore
       return window.Zone.current._properties[opts.zoneIdentifier] === true;
-    }
+    };
 
     opts.routingEventListener = function() {
       opts.bootstrappedNgZone.run(() => {
         // See https://github.com/single-spa/single-spa-angular/issues/86
         // Zone is unaware of the single-spa navigation change and so Angular change detection doesn't work
         // unless we tell Zone that something happened
-      })
-    }
+      });
+    };
   });
 }
 
@@ -82,14 +82,14 @@ function mount(opts, props) {
       const containerEl = getContainerEl(domElementGetter);
       containerEl.innerHTML = opts.template;
 
-      const bootstrapPromise = opts.bootstrapFunction(props)
+      const bootstrapPromise = opts.bootstrapFunction(props);
       if (!(bootstrapPromise instanceof Promise)) {
         throw Error(`single-spa-angular: the opts.bootstrapFunction must return a promise, but instead returned a '${typeof bootstrapPromise}' that is not a Promise`);
       }
 
       return bootstrapPromise.then(module => {
         if (!module || typeof module.destroy !== 'function') {
-          throw Error(`single-spa-angular: the opts.bootstrapFunction returned a promise that did not resolve with a valid Angular module. Did you call platformBrowser().bootstrapModuleFactory() correctly?`)
+          throw Error(`single-spa-angular: the opts.bootstrapFunction returned a promise that did not resolve with a valid Angular module. Did you call platformBrowser().bootstrapModuleFactory() correctly?`);
         }
 
         const singleSpaPlatformLocation: SingleSpaPlatformLocation | null = module.injector.get(
@@ -116,7 +116,7 @@ function mount(opts, props) {
 
         opts.bootstrappedNgZone = ngZone;
         opts.bootstrappedNgZone._inner._properties[opts.zoneIdentifier] = true;
-        window.addEventListener('single-spa:routing-event', opts.routingEventListener)
+        window.addEventListener('single-spa:routing-event', opts.routingEventListener);
         opts.bootstrappedModule = module;
         return module;
       });
@@ -131,7 +131,7 @@ function unmount(opts, props) {
       const routerRef = opts.bootstrappedModule.injector.get(opts.Router);
       routerRef.dispose();
     }
-    window.removeEventListener('single-spa:routing-event', opts.routingEventListener)
+    window.removeEventListener('single-spa:routing-event', opts.routingEventListener);
     opts.bootstrappedModule.destroy();
     if (opts.AnimationEngine) {
       /*
@@ -175,15 +175,15 @@ function getContainerEl(domElementGetter) {
 }
 
 function chooseDomElementGetter(opts, props) {
-  props = props && props.customProps ? props.customProps : props
+  props = props && props.customProps ? props.customProps : props;
   if (props.domElement) {
-    return () => props.domElement
+    return () => props.domElement;
   } else if (props.domElementGetter) {
-    return props.domElementGetter
+    return props.domElementGetter;
   } else if (opts.domElementGetter) {
-    return opts.domElementGetter
+    return opts.domElementGetter;
   } else {
-    return defaultDomElementGetter(props.name)
+    return defaultDomElementGetter(props.name);
   }
 }
 
@@ -198,10 +198,10 @@ function defaultDomElementGetter(name) {
     }
 
     return domElement;
-  }
+  };
 }
 
-type SingleSpaAngularOpts = {
+interface SingleSpaAngularOpts {
   NgZone: any;
   bootstrapFunction(props: AppProps): Promise<any>;
   updateFunction?(props: AppProps): Promise<any>;

--- a/src/builders/single-spa-webpack-builder.ts
+++ b/src/builders/single-spa-webpack-builder.ts
@@ -1,5 +1,5 @@
 import { Configuration } from 'webpack';
-import { getSystemPath, Path, tags } from '@angular-devkit/core'
+import { getSystemPath, Path } from '@angular-devkit/core';
 import { BuilderContext } from '@angular-devkit/architect';
 import * as webpackMerge from 'webpack-merge';
 
@@ -23,13 +23,15 @@ export function buildWebpackConfig(root: Path, config: string, baseWebpackConfig
         }
       ]
     }
-  }
+  };
 
   const customWebpackConfig = config ? require(`${getSystemPath(root)}/${config}`) : {};
 
   const mergedConfig: any = webpackMerge.smart(baseWebpackConfig, singleSpaConfig, customWebpackConfig);
 
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   removePluginByName(mergedConfig.plugins, 'IndexHtmlWebpackPlugin');
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   removeMiniCssExtract(mergedConfig);
 
   if (Array.isArray(mergedConfig.entry.styles)) {
@@ -61,7 +63,7 @@ function removeMiniCssExtract(config) {
     if (rule.use) {
       const cssMiniExtractIndex = rule.use.findIndex(use => typeof use === 'string' && use.includes('mini-css-extract-plugin'));
       if (cssMiniExtractIndex >= 0) {
-        rule.use[cssMiniExtractIndex] = {loader: 'style-loader'}
+        rule.use[cssMiniExtractIndex] = {loader: 'style-loader'};
       }
     }
   });

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -1,5 +1,5 @@
 import * as webpackMerge from 'webpack-merge';
-import * as path from 'path'
+import * as path from 'path';
 
 export default (config, options) => {
   const singleSpaConfig = {
@@ -14,7 +14,7 @@ export default (config, options) => {
       historyApiFallback: false,
       contentBase: path.resolve(process.cwd(), 'src'),
       headers: {
-          'Access-Control-Allow-Headers': '*',
+        'Access-Control-Allow-Headers': '*',
       },
     },
     module: {
@@ -26,12 +26,14 @@ export default (config, options) => {
         }
       ]
     }
-  }
+  };
 
   // @ts-ignore
-  const mergedConfig: any = webpackMerge.smart(config, singleSpaConfig)
+  const mergedConfig: any = webpackMerge.smart(config, singleSpaConfig);
 
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   removePluginByName(mergedConfig.plugins, 'IndexHtmlWebpackPlugin');
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   removeMiniCssExtract(mergedConfig);
 
   if (Array.isArray(mergedConfig.entry.styles)) {
@@ -48,7 +50,7 @@ export default (config, options) => {
   delete mergedConfig.optimization.splitChunks;
 
   return mergedConfig;
-}
+};
 
 function removePluginByName(plugins, name) {
   const pluginIndex = plugins.findIndex(plugin => plugin.constructor.name === name);
@@ -63,7 +65,7 @@ function removeMiniCssExtract(config) {
     if (rule.use) {
       const cssMiniExtractIndex = rule.use.findIndex(use => typeof use === 'string' && use.includes('mini-css-extract-plugin'));
       if (cssMiniExtractIndex >= 0) {
-        rule.use[cssMiniExtractIndex] = {loader: 'style-loader'}
+        rule.use[cssMiniExtractIndex] = {loader: 'style-loader'};
       }
     }
   });


### PR DESCRIPTION
Since we support 3.x because there are a lot of apps that still run using Angular 6-8 I would love to have this as a quality gateway.