### PR TITLE
Fix/missing get single spa extra providers

### DIFF
--- a/src/schematics/ng-add/_files/src/main.single-spa.ts.template
+++ b/src/schematics/ng-add/_files/src/main.single-spa.ts.template
@@ -1,6 +1,5 @@
 <% if (!atLeastAngular8) { %>import 'core-js/es7/reflect';<% } %>
-<% if (routing) { %>import { enableProdMode, NgZone } from '@angular/core';<% } %>
-<% if (!routing) { %>import { enableProdMode, NgZone } from '@angular/core';<% } %>
+import { enableProdMode, NgZone } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';<% if (routing) { %>
 import { Router } from '@angular/router';<% } if (usingBrowserAnimationsModule) { %>
 import { ɵAnimationEngine as AnimationEngine } from '@angular/animations/browser'; <% } %>

--- a/src/schematics/ng-add/_files/src/main.single-spa.ts.template
+++ b/src/schematics/ng-add/_files/src/main.single-spa.ts.template
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';<% } if (usingBrowserAnimationsModule) 
 import { ɵAnimationEngine as AnimationEngine } from '@angular/animations/browser'; <% } %>
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
-import singleSpaAngular from 'single-spa-angular';
+import singleSpaAngular<% if (routing) { %>, { getSingleSpaExtraProviders }<% } %> from 'single-spa-angular';
 import { singleSpaPropsSubject } from './single-spa/single-spa-props';
 
 if (environment.production) {
@@ -16,7 +16,7 @@ if (environment.production) {
 const lifecycles = singleSpaAngular({
   bootstrapFunction: singleSpaProps => {
     singleSpaPropsSubject.next(singleSpaProps);
-    return platformBrowserDynamic().bootstrapModule(AppModule);
+    return platformBrowserDynamic(<% if (routing) { %>getSingleSpaExtraProviders()<% } %>).bootstrapModule(AppModule);
   },
   template: '<<%= prefix %>-root />',<% if (routing) { %>
   Router,<% } %>

--- a/src/schematics/ng-add/index.spec.ts
+++ b/src/schematics/ng-add/index.spec.ts
@@ -66,6 +66,12 @@ describe('ng-add', () => {
     expect(mainModuleContent.indexOf('@angular/router')).toBeGreaterThan(-1);
   });
 
+  test('should include getSingleSpaExtraProviders if routing is enabled', () => {
+    const tree = testRunner.runSchematic<NgAddOptions>('ng-add', { routing: true }, defaultAppTree);
+    const mainModuleContent = getFileContent(tree, '/projects/ss-angular-cli-app/src/main.single-spa.ts');
+    expect(mainModuleContent.indexOf('getSingleSpaExtraProviders()')).toBeGreaterThan(-1);
+  });
+
   test('should modify angular.json', () => {
     const tree = testRunner.runSchematic<NgAddOptions>('ng-add', { routing: true, project: 'ss-angular-cli-app' }, defaultAppTree);
     const angularJSON = JSON.parse(getFileContent(tree, '/angular.json'));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Applications generated with the 3.x schematic do not include a call to `getSingleSpaExtraProviders`. 

Resolves #209 

## What is the new behavior?

The generated bootstrapFunction includes the call to getSingleSpaExtraProviders.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```