### PR TITLE
Library Name

### DIFF
--- a/schematics/ng-add/_files/extra-webpack.config.js.template
+++ b/schematics/ng-add/_files/extra-webpack.config.js.template
@@ -1,7 +1,7 @@
 const singleSpaAngularWebpack = require('single-spa-angular/lib/webpack').default;
 
-module.exports = config => {
-  const singleSpaWebpackConfig = singleSpaAngularWebpack(config);
+module.exports = (config, options) => {
+  const singleSpaWebpackConfig = singleSpaAngularWebpack(config, options);
 
   // Feel free to modify this webpack config however you'd like to
   return singleSpaWebpackConfig;

--- a/schematics/ng-add/index.ts
+++ b/schematics/ng-add/index.ts
@@ -33,6 +33,8 @@ import {
 interface CustomWebpackBuilderOptions extends BrowserBuilderOptions {
   customWebpackConfig: {
     path: string;
+    libraryName?: string;
+    libraryTarget?: string;
   };
 }
 
@@ -95,7 +97,7 @@ export function updateConfiguration(options: NgAddOptions) {
     const workspacePath = getWorkspacePath(host);
 
     if (atLeastAngular8()) {
-      updateProjectNewAngular(context, clientProject);
+      updateProjectNewAngular(context, clientProject, project.name);
       updateTSConfig(host, clientProject);
     } else {
       updateProjectOldAngular(context, clientProject, project);
@@ -130,7 +132,11 @@ function updateProjectOldAngular(
   clientProject.architect!['single-spa-serve'].options.browserTarget = `${project.name}:single-spa`;
 }
 
-function updateProjectNewAngular(context: SchematicContext, clientProject: WorkspaceProject): void {
+function updateProjectNewAngular(
+  context: SchematicContext,
+  clientProject: WorkspaceProject,
+  projectName: string,
+): void {
   context.logger.info('Using @angular-devkit/custom-webpack builder.');
 
   const buildTarget = clientProject.architect!.build!;
@@ -140,6 +146,8 @@ function updateProjectNewAngular(context: SchematicContext, clientProject: Works
   buildTarget.options.main = join(clientProject.root, 'src/main.single-spa.ts');
   (buildTarget.options as CustomWebpackBuilderOptions).customWebpackConfig = {
     path: join(clientProject.root, 'extra-webpack.config.js'),
+    libraryName: projectName,
+    libraryTarget: 'umd',
   };
 
   updateConfigurationsAndDisableOutputHashing(clientProject);

--- a/schematics/ng-add/tests/index.spec.ts
+++ b/schematics/ng-add/tests/index.spec.ts
@@ -129,7 +129,11 @@ describe('ng-add', () => {
     const expectedCustomWebpackConfigPath = normalize(
       'projects/ss-angular-cli-app/extra-webpack.config.js',
     );
-    expect(customWebpackConfigPath).toEqual(expectedCustomWebpackConfigPath);
+    expect(ssApp.architect.build.options.customWebpackConfig).toEqual({
+      libraryName: 'ss-angular-cli-app',
+      libraryTarget: 'umd',
+      path: expectedCustomWebpackConfigPath,
+    });
   });
 
   test('should add build:single-spa npm script', async () => {

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -1,11 +1,16 @@
 import * as webpackMerge from 'webpack-merge';
 import * as path from 'path';
+import * as fs from 'fs';
+import { findUp } from '@angular/cli/utilities/find-up';
 
-export default (config: any) => {
+export default (config: any, options?: any) => {
+  const libraryName = getLibraryName(options);
+
   const singleSpaConfig: any = {
     output: {
-      library: 'app3',
-      libraryTarget: 'umd',
+      library: libraryName,
+      libraryTarget: options?.customWebpackConfig?.libraryTarget ?? 'umd',
+      jsonpFunction: 'webpackJsonp' + libraryName,
     },
     externals: ['zone.js'],
     devServer: {
@@ -27,6 +32,11 @@ export default (config: any) => {
   };
 
   const mergedConfig: any = webpackMerge.smart(config, singleSpaConfig);
+
+  if (mergedConfig.output.libraryTarget === 'system') {
+    // Don't used named exports when exporting in System.register format.
+    delete mergedConfig.output.library;
+  }
 
   removePluginByName(mergedConfig.plugins, 'IndexHtmlWebpackPlugin');
   removeMiniCssExtract(mergedConfig);
@@ -74,4 +84,43 @@ function removeMiniCssExtract(config: any) {
       }
     }
   });
+}
+
+function getLibraryName(options: any) {
+  if (options?.customWebpackConfig?.libraryName) {
+    return options.customWebpackConfig.libraryName;
+  }
+
+  const projectName = getProjectNameFromAngularJson();
+  if (projectName) return projectName;
+
+  console.warn(
+    'Warning: single-spa-angular could not determine a library name to use and has used a default value.',
+  );
+  console.info('This may cause issues if this app uses code-splitting or lazy loading.');
+  if (!options) {
+    console.info('You may also need to update extra-webpack.config.json.');
+  }
+  console.info(
+    'See <https://single-spa.js.org/docs/ecosystem-angular/#use-custom-webpack> for information on how to resolve this.',
+  );
+
+  return 'angular_single_spa_project';
+}
+
+function getProjectNameFromAngularJson(): string | null {
+  const angularJsonPath = findUp(['angular.json', '.angular.json'], process.cwd());
+  if (!angularJsonPath) return null;
+
+  const angularJson = JSON.parse(fs.readFileSync(angularJsonPath, 'utf8'));
+  if (!angularJson.projects) return null;
+
+  var projects = Object.keys(angularJson.projects);
+
+  // if there is exactly one project in the workspace, then that must be this one.
+  if (projects.length === 1) return projects[0];
+
+  // If we reach here there are multiple (or zero) projects in angular.json
+  // we cannot tell which one to use, so we will end up using the default.
+  return null;
 }

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -115,7 +115,7 @@ function getProjectNameFromAngularJson(): string | null {
   const angularJson = JSON.parse(fs.readFileSync(angularJsonPath, 'utf8'));
   if (!angularJson.projects) return null;
 
-  var projects = Object.keys(angularJson.projects);
+  const projects = Object.keys(angularJson.projects);
 
   // if there is exactly one project in the workspace, then that must be this one.
   if (projects.length === 1) return projects[0];


### PR DESCRIPTION
Sorry for the delay in getting this put together.

This pull request incorporates two different approaches. The two different commits show each of the approaches.

The first approach is simply a string parameter passed to `singleSpaAngularWebpack`. To be backwards compatible, it falls back to trying to get the project name from angular.json. If that fails, it uses a default value, and prints a warning message that explains why a default value might be undesirable, and a link to information on how to fix it.

The second approach is similar, but uses a property defined in angular.json. It has equivalent fallback to the first approach. For this second approach, I've also shown an example of another property (`libraryTarget`) that might be helpful, especially since that was supported back pre-Angular 8 builder.

Once we finalize the approach we want to take, and get this into mergeable shape for the 4.x branch series, I'll backport it to 3.x. (See the 3.xLibraryName branch in my fork if desired).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

Not clear what the best way to even approach automated testing would be. Trying to parse the webpack output seems like a bad idea. I suppose technically setting something up to try to pull it in via named amd could work, but that feels obnoxious at best.

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?

Issue Number: #220 
## Does this PR introduce a breaking change?

- [x] No
