### PR TITLE
fix: revive schematics functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "files": [
     "lib",
     "parcel",
-    "src/schematics/ng-add/schema.json"
+    "src/schematics/ng-add/schema.json",
+    "builders.json",
+    "schematics.json"
   ],
   "author": "Joel Denning",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "files": [
     "lib",
     "parcel",
-    "src/schematics/ng-add/schema.json",
+    "src/**/schema.json",
     "builders.json",
     "schematics.json"
   ],


### PR DESCRIPTION
Include ignored builders.json and schematics.json files into package so ng add
will stop complain about missing collections.

Closes: #226