### PR TITLE
fix: allow removal mini-css-extract from object rules

### DIFF
--- a/src/webpack/index.spec.ts
+++ b/src/webpack/index.spec.ts
@@ -1,0 +1,73 @@
+import singleSpaAngularWebpack from './index';
+
+class MiniCssExtractPlugin {}
+
+class AnotherPlugin {}
+
+describe('Webpack config', () => {
+  const defaultConfig = { entry: {}, optimization: {}, plugins: [] };
+
+  beforeEach(async () => {});
+
+  describe('Remove MiniCssExtractPlugin', () => {
+    test('should remove Mini Css Extract from plugins', async () => {
+      // GIVEN
+      const config = { plugins: [new MiniCssExtractPlugin(), new AnotherPlugin()] };
+
+      // TEST
+      const singleSpaConfig = singleSpaAngularWebpack({ ...defaultConfig, ...config });
+
+      // EXPECT
+      expect(singleSpaConfig.plugins).toHaveLength(1);
+      expect(singleSpaConfig.plugins[0].constructor.name).toBe('AnotherPlugin');
+    });
+
+    test('should remove Mini Css Extract from string rules and replace by style-loader', async () => {
+      // GIVEN
+      const config = { module: { rules: [{ use: ['mini-css-extract-plugin', 'other-loader'] }] } };
+
+      // TEST
+      const singleSpaConfig = singleSpaAngularWebpack({ ...defaultConfig, ...config });
+
+      // EXPECT
+      expect(singleSpaConfig.module.rules[0]).toEqual({
+        use: [{ loader: 'style-loader' }, 'other-loader'],
+      });
+    });
+
+    test('should remove Mini Css Extract from object rules and replace by style-loader', async () => {
+      // GIVEN
+      const config = {
+        module: {
+          rules: [{ use: [{ loader: 'mini-css-extract-plugin' }, { loader: 'other-loader' }] }],
+        },
+      };
+
+      // TEST
+      const singleSpaConfig = singleSpaAngularWebpack({ ...defaultConfig, ...config });
+
+      // EXPECT
+      expect(singleSpaConfig.module.rules[0]).toEqual({
+        use: [{ loader: 'style-loader' }, { loader: 'other-loader' }],
+      });
+    });
+
+    test('should not break if no Mini Css Extract configurations specified', async () => {
+      // GIVEN
+      const config = {
+        plugins: [new AnotherPlugin()],
+        module: { rules: [{ use: ['other-loader', { loader: 'other-loader' }] }] },
+      };
+
+      // TEST
+      const singleSpaConfig = singleSpaAngularWebpack({ ...defaultConfig, ...config });
+
+      // EXPECT
+      expect(singleSpaConfig.plugins).toHaveLength(1);
+      expect(singleSpaConfig.plugins[0].constructor.name).toEqual('AnotherPlugin');
+      expect(singleSpaConfig.module.rules[0]).toEqual({
+        use: ['other-loader', { loader: 'other-loader' }],
+      });
+    });
+  });
+});

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -77,7 +77,9 @@ function removeMiniCssExtract(config: any) {
   config.module.rules.forEach((rule: any) => {
     if (rule.use) {
       const cssMiniExtractIndex = rule.use.findIndex(
-        (use: any) => typeof use === 'string' && use.includes('mini-css-extract-plugin'),
+        (use: any) =>
+          (typeof use === 'string' && use.includes('mini-css-extract-plugin')) ||
+          (typeof use === 'object' && use.loader && use.loader.includes('mini-css-extract-plugin')),
       );
       if (cssMiniExtractIndex >= 0) {
         rule.use[cssMiniExtractIndex] = { loader: 'style-loader' };


### PR DESCRIPTION
PR concerning my post on [https://single-spa.slack.com/archives/C8R6U7MT7/p1599556983407100](slack)


## What is the current behavior?

The MiniCssExtract plugin should be replaced by style-laoder in the webpack config.

Correctly replaced:
```
{ 
  module: { 
    rules: [ { use: ['mini-css-extract-plugin'] } ]
}
```

Not replaced:
```
{ 
  module: { 
    rules: [ { use: [{loader:'mini-css-extract-plugin'}] } ]
}
```

Issue Number: N/A

## What is the new behavior?

You can now receive loader specified as objects

## Does this PR introduce a breaking change?

```
[ ] Yes
[ X ] No
```
