### PR TITLE
refactor(webpack): add extraOptions param for default webpack export

### DIFF
--- a/src/webpack/index.spec.ts
+++ b/src/webpack/index.spec.ts
@@ -70,4 +70,24 @@ describe('Webpack config', () => {
       });
     });
   });
+
+  describe("Don't remove MiniCssExtractPlugin", () => {
+    test('should not remove the Mini Css Extract plugin', async () => {
+      // GIVEN
+      const config = { plugins: [new MiniCssExtractPlugin(), new AnotherPlugin()] };
+
+      // TEST
+      const singleSpaConfig = singleSpaAngularWebpack(
+        { ...defaultConfig, ...config },
+        {},
+        {
+          removeMiniCssExtract: false,
+        },
+      );
+
+      // EXPECT
+      expect(singleSpaConfig.plugins).toHaveLength(2);
+      expect(singleSpaConfig.plugins[0].constructor.name).toBe('MiniCssExtractPlugin');
+    });
+  });
 });

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -3,8 +3,16 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { findUp } from '@angular/cli/utilities/find-up';
 
-export default (config: any, options?: any) => {
+export interface DefaultExtraOpts {
+  removeMiniCssExtract: boolean;
+}
+const defaultExtraOpts = {
+  removeMiniCssExtract: true,
+};
+
+export default (config: any, options?: any, extraOptions?: DefaultExtraOpts) => {
   const libraryName = getLibraryName(options);
+  const extraOpts = { ...defaultExtraOpts, ...extraOptions };
 
   const singleSpaConfig: any = {
     output: {
@@ -39,7 +47,9 @@ export default (config: any, options?: any) => {
   }
 
   removePluginByName(mergedConfig.plugins, 'IndexHtmlWebpackPlugin');
-  removeMiniCssExtract(mergedConfig);
+  if (extraOpts.removeMiniCssExtract) {
+    removeMiniCssExtract(mergedConfig);
+  }
 
   if (Array.isArray(mergedConfig.entry.styles)) {
     // We want the global styles to be part of the "main" entry. The order of strings in this array


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Current webpack always removes the MiniCssExtract plugin which is used in Angular projects to generate css files, instead using the style-loader to inject the css as "style" tags. We require the files to be generated so that we can manually control them, because the styles injected are not remove at unmount time.


Issue Number: N/A

## What is the new behavior?

Add "extraOptions" parameter ('single-spa-angular/lib/webpack').default that allows users to pass extra options and control how the "singleSpaAngularWebpack" function modifies the final webpack configuration.

Current available options:
const defaultExtraOpts = {
  removeMiniCssExtract: true, //  boolean - remove or keep the MiniCssExtract plugin which generates css files at build time
};

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
