### PR TITLE
fix: provide `umdId` for the `single-spa-angular/internals`

### DIFF
--- a/libs/single-spa-angular/internals/package.json
+++ b/libs/single-spa-angular/internals/package.json
@@ -3,6 +3,7 @@
     "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
     "lib": {
       "entryFile": "src/index.ts",
+      "umdId": "single-spa-angular-internals",
       "flatModuleFile": "single-spa-angular-internals"
     }
   }


### PR DESCRIPTION
Closes #204 

This provides a valid UMD id for the `internals` package. Since `single-spa-angular` tries to resolve the `single-spa-angular/internals` package using `single-spa-angular-internals` id, but ng-packagr generated `single-spa-angular/internals` UMD id.