### PR TITLE
chore: drop old Angular related code

### DIFF
--- a/schematics/ng-add/_files/src/main.single-spa.ts.template
+++ b/schematics/ng-add/_files/src/main.single-spa.ts.template
@@ -1,4 +1,3 @@
-<% if (!atLeastAngular8) { %>import 'core-js/es7/reflect';<% } %>
 <% if (routing) { %>import { enableProdMode, NgZone } from '@angular/core';<% } %>
 <% if (!routing) { %>import { enableProdMode, NgZone } from '@angular/core';<% } %>
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';<% if (routing) { %>

--- a/schematics/ng-add/index.ts
+++ b/schematics/ng-add/index.ts
@@ -72,7 +72,6 @@ export function createMainEntry(options: NgAddOptions): Rule {
 
     const templateSource = apply(url('./_files'), [
       applyTemplates({
-        atLeastAngular8: atLeastAngular8(),
         prefix: project.workspace.prefix,
         routing: options.routing,
         usingBrowserAnimationsModule: options.usingBrowserAnimationsModule,
@@ -99,12 +98,8 @@ export function updateConfiguration(options: NgAddOptions) {
     }
     const workspacePath = getWorkspacePath(host);
 
-    if (atLeastAngular8()) {
-      updateProjectNewAngular(context, clientProject, project.name);
-      updateTSConfig(host, clientProject);
-    } else {
-      updateProjectOldAngular(context, clientProject, project);
-    }
+    updateProjectNewAngular(context, clientProject, project.name);
+    updateTSConfig(host, clientProject);
 
     host.overwrite(workspacePath, JSON.stringify(workspace, null, 2));
 
@@ -113,26 +108,6 @@ export function updateConfiguration(options: NgAddOptions) {
     context.logger.info(clientProject.architect.build.builder);
     return host;
   };
-}
-
-function updateProjectOldAngular(
-  context: SchematicContext,
-  clientProject: WorkspaceProject,
-  project: any,
-) {
-  context.logger.info('Using single-spa-angular builder for Angular versions before 8');
-
-  // Copy configuration from build architect
-  clientProject!.architect!['single-spa'] = clientProject.architect!.build;
-  clientProject!.architect!['single-spa'].builder = 'single-spa-angular:build';
-  clientProject!.architect![
-    'single-spa'
-  ].options.main = `${project.workspace.sourceRoot}/main.single-spa.ts`;
-
-  // Copy configuration from the serve architect
-  clientProject.architect!['single-spa-serve'] = clientProject.architect!.serve;
-  clientProject.architect!['single-spa-serve'].builder = 'single-spa-angular:dev-server';
-  clientProject.architect!['single-spa-serve'].options.browserTarget = `${project.name}:single-spa`;
 }
 
 function updateProjectNewAngular(
@@ -208,11 +183,6 @@ function getClientProject(
   }
 
   return { name: project!, workspace: clientProject };
-}
-
-function atLeastAngular8(): boolean {
-  const { VERSION } = require('@angular/core');
-  return Number(VERSION.major) >= 8;
 }
 
 function updateConfigurationsAndDisableOutputHashing(clientProject: WorkspaceProject): void {


### PR DESCRIPTION
This PR removes an unused code, since we have a semver requirements inside our package.json `@angular/core: >=9`.