### PR TITLE
fix: provide `deployUrl` through build target instead `--deploy-url`

### DIFF
--- a/schematics/ng-add/index.ts
+++ b/schematics/ng-add/index.ts
@@ -17,7 +17,7 @@ export default function (options: NgAddOptions): Rule {
       addDependencies(),
       createMainEntry(project, options),
       updateConfiguration(workspace, project, host, options),
-      addNPMScripts(options),
+      addNPMScripts(workspace, project, host, options),
       showWarningIfRoutingIsEnabled(options),
     ]);
   };

--- a/schematics/ng-add/rules/utils.ts
+++ b/schematics/ng-add/rules/utils.ts
@@ -1,0 +1,14 @@
+import { workspaces } from '@angular-devkit/core';
+import { SchematicsException } from '@angular-devkit/schematics';
+
+export function getBuildTarget(
+  project: workspaces.ProjectDefinition,
+): workspaces.TargetDefinition | never {
+  const buildTarget = project.targets.get('build');
+
+  if (!buildTarget) {
+    throw new SchematicsException(`Project target "build" not found.`);
+  }
+
+  return buildTarget;
+}

--- a/schematics/ng-add/schema.d.ts
+++ b/schematics/ng-add/schema.d.ts
@@ -2,4 +2,7 @@ export interface Schema {
   project?: string;
   routing?: boolean;
   usingBrowserAnimationsModule?: boolean;
+  // This actually will still infer to `number` type, this is done to specify
+  // that `4200` is used by default.
+  port?: 4200 | number;
 }

--- a/schematics/ng-add/schema.json
+++ b/schematics/ng-add/schema.json
@@ -22,6 +22,12 @@
       "description": "A value of true means the angular application uses BrowserAnimationsModule",
       "default": false,
       "x-prompt": "Does your application use BrowserAnimationsModule?"
+    },
+    "port": {
+      "type": "number",
+      "description": "Port to listen on",
+      "default": 4200,
+      "x-prompt": "(todo): ask Joel to provide the prompt"
     }
   },
   "required": []

--- a/schematics/ng-add/schema.json
+++ b/schematics/ng-add/schema.json
@@ -27,7 +27,7 @@
       "type": "number",
       "description": "Port to listen on",
       "default": 4200,
-      "x-prompt": "(todo): ask Joel to provide the prompt"
+      "x-prompt": "What port should your project run on?"
     }
   },
   "required": []

--- a/schematics/ng-add/tests/add-scripts.spec.ts
+++ b/schematics/ng-add/tests/add-scripts.spec.ts
@@ -47,24 +47,31 @@ describe('ng-add', () => {
       .toPromise();
 
     const tree = await testRunner
-      .runSchematicAsync('ng-add', { project: 'second-cool-app' }, workspaceTree)
+      .runSchematicAsync('ng-add', { project: 'second-cool-app', port: 4201 }, workspaceTree)
       .toPromise();
 
     const { scripts } = JSON.parse(tree.get('/package.json')!.content.toString());
 
-    // Assert
-    expect(scripts['build:single-spa:first-cool-app']).toBe(
-      'ng build first-cool-app --prod --deploy-url http://localhost:4200/',
-    );
+    // Assert `package.json` scripts
+    expect(scripts['build:single-spa:first-cool-app']).toBe('ng build first-cool-app --prod');
     expect(scripts['serve:single-spa:first-cool-app']).toBe(
-      'ng s --project first-cool-app --disable-host-check --port 4200 --deploy-url http://localhost:4200/ --live-reload false',
+      'ng s --project first-cool-app --disable-host-check --port 4200 --live-reload false',
     );
 
-    expect(scripts['build:single-spa:second-cool-app']).toBe(
-      'ng build second-cool-app --prod --deploy-url http://localhost:4201/',
-    );
+    expect(scripts['build:single-spa:second-cool-app']).toBe('ng build second-cool-app --prod');
     expect(scripts['serve:single-spa:second-cool-app']).toBe(
-      'ng s --project second-cool-app --disable-host-check --port 4201 --deploy-url http://localhost:4201/ --live-reload false',
+      'ng s --project second-cool-app --disable-host-check --port 4201 --live-reload false',
+    );
+
+    // Assert `angular.json` `deployUrl` option
+    const config = JSON.parse(tree.get('/angular.json')!.content.toString());
+
+    expect(config.projects['first-cool-app'].architect.build.options.deployUrl).toBe(
+      'http://localhost:4200/',
+    );
+
+    expect(config.projects['second-cool-app'].architect.build.options.deployUrl).toBe(
+      'http://localhost:4201/',
     );
   });
 
@@ -76,22 +83,33 @@ describe('ng-add', () => {
     await testRunner.runSchematicAsync('ng-add', undefined, workspaceTree).toPromise();
 
     const tree = await testRunner
-      .runSchematicAsync('ng-add', { project: 'additional-project' }, workspaceTree)
+      .runSchematicAsync('ng-add', { project: 'additional-project', port: 4201 }, workspaceTree)
       .toPromise();
 
     const { scripts } = JSON.parse(tree.get('/package.json')!.content.toString());
 
-    // Arrange
-    expect(scripts['build:single-spa']).toBe('ng build --prod --deploy-url http://localhost:4200/');
+    // Assert `package.json` scripts
+    expect(scripts['build:single-spa']).toBe('ng build --prod');
     expect(scripts['serve:single-spa']).toBe(
-      'ng s --disable-host-check --port 4200 --deploy-url http://localhost:4200/ --live-reload false',
+      'ng s --disable-host-check --port 4200 --live-reload false',
     );
 
     expect(scripts['build:single-spa:additional-project']).toBe(
-      'ng build additional-project --prod --deploy-url http://localhost:4201/',
+      'ng build additional-project --prod',
     );
     expect(scripts['serve:single-spa:additional-project']).toBe(
-      'ng s --project additional-project --disable-host-check --port 4201 --deploy-url http://localhost:4201/ --live-reload false',
+      'ng s --project additional-project --disable-host-check --port 4201 --live-reload false',
+    );
+
+    // Assert `angular.json` `deployUrl` option
+    const config = JSON.parse(tree.get('/angular.json')!.content.toString());
+
+    expect(config.projects['default-project'].architect.build.options.deployUrl).toBe(
+      'http://localhost:4200/',
+    );
+
+    expect(config.projects['additional-project'].architect.build.options.deployUrl).toBe(
+      'http://localhost:4201/',
     );
   });
 });


### PR DESCRIPTION
Hey @joeldenning . The `--deploy-url` is deprecated:

![image](https://user-images.githubusercontent.com/7337691/110179659-211ca000-7e11-11eb-98fa-931a2ebea578.png)

Updated schematics to provide `deployUrl` through `angular.json`.

Also added `port` option to schema since it will be easier to ask user for the port except of trying to detect it manually.