### PR TITLE
fix: specify `webSocketURL` within the webpack config

### DIFF
--- a/libs/single-spa-angular/webpack/index.ts
+++ b/libs/single-spa-angular/webpack/index.ts
@@ -54,6 +54,16 @@ export default (config: any, options?: Options, extraOptions?: DefaultExtraOptio
     devtool: resolveDevtool(options),
   };
 
+  // Do not set the `client.webSocketURL` configuration if there's no host and port.
+  if (config.devServer?.host && config.devServer.port) {
+    singleSpaConfig.devServer.client = {
+      webSocketURL: {
+        hostname: config.devServer.host,
+        port: config.devServer.port,
+      },
+    };
+  }
+
   const mergedConfig = mergeConfigs(config, singleSpaConfig);
 
   if (mergedConfig.output.libraryTarget === 'system') {


### PR DESCRIPTION
Included a fix from that comment: https://github.com/single-spa/single-spa-angular/issues/395#issuecomment-994475359