### PR TITLE
fix: remove `"browser": "src/main.ts"` from `angular.json` (Fixes Issue #507)

### DIFF
--- a/schematics/ng-add/rules/update-configuration.ts
+++ b/schematics/ng-add/rules/update-configuration.ts
@@ -141,6 +141,7 @@ function updateBuildTarget(
 
   buildTarget.builder = '@angular-builders/custom-webpack:browser';
   buildTarget.options!.main = join(root, normalize('src/main.single-spa.ts'));
+  delete buildTarget.options!.browser;
   (buildTarget.options as unknown as CustomWebpackBuilderOptions).customWebpackConfig = {
     path: join(root, 'extra-webpack.config.js'),
     libraryName: options.project,

--- a/schematics/ng-add/tests/index.spec.ts
+++ b/schematics/ng-add/tests/index.spec.ts
@@ -147,6 +147,7 @@ describe('ng-add', () => {
     const expectedCustomWebpackConfigPath = normalize(
       'projects/ss-angular-cli-app/extra-webpack.config.js',
     );
+    expect(ssApp.architect.build.options.hasOwnProperty('browser')).toBeFalsy();
     expect(ssApp.architect.build.options.customWebpackConfig).toEqual({
       libraryName: 'ss-angular-cli-app',
       libraryTarget: 'umd',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Angular v17 onwards `"browser": "src/main.ts"` is getting added to the build options of `angular.json` which causes the following error during build/serve:
```
Error: Schema validation failed with the following errors:
  Data path "" must NOT have additional properties(browser).
```

Issue Number: #507 

## What is the new behavior?
The PR removes the browser key from the build options if it exists. The angular v17 application should now build without error.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
