### PR TITLE
Remove Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,8 +1,8 @@
 # These are supported funding model platforms
 
-github: [joeldenning]
+github: ["joeldenning"]
 patreon: # Replace with a single Patreon username
-open_collective: single-spa
+open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry


### PR DESCRIPTION
Open Collective is shutting down - see https://opencollective.com/foundation/updates/announcement-we-are-dissolving-open-collective-foundation-at-the-end-of-this-year

Happy to add other Github sponsor profiles to this project, since I'm not the primary maintainer of this repository.