### PR TITLE
Don't used named exports when exporting in ES Module format.

### DIFF
--- a/libs/single-spa-angular/webpack/index.spec.ts
+++ b/libs/single-spa-angular/webpack/index.spec.ts
@@ -187,5 +187,40 @@ describe('Webpack config', () => {
       // Assert
       expect(singleSpaConfig.devtool).toEqual('source-map');
     });
+
+    test('should not set a library name when exporting in module format', () => {
+      // Arrange
+      const customWebpackConfig = {
+        libraryName: 'my-library',
+        libraryTarget: 'module'
+      };
+
+      // Act
+      const singleSpaConfig = singleSpaAngularWebpack(
+        { ...defaultConfig },
+        { customWebpackConfig },
+      );
+
+      // Assert
+      expect(singleSpaConfig.output.library).toBeUndefined();
+    });
+
+
+    test('should set a library name when exporting in umd format', () => {
+      // Arrange
+      const customWebpackConfig = {
+        libraryName: 'my-library',
+        libraryTarget: 'umd'
+      };
+
+      // Act
+      const singleSpaConfig = singleSpaAngularWebpack(
+        { ...defaultConfig },
+        { customWebpackConfig },
+      );
+
+      // Assert
+      expect(singleSpaConfig.output.library).toBe(customWebpackConfig.libraryName);
+    });
   });
 });

--- a/libs/single-spa-angular/webpack/index.ts
+++ b/libs/single-spa-angular/webpack/index.ts
@@ -63,8 +63,8 @@ export default (config: any, options?: Options, extraOptions?: DefaultExtraOptio
 
   const mergedConfig = mergeConfigs(config, singleSpaConfig);
 
-  if (mergedConfig.output.libraryTarget === 'system') {
-    // Don't used named exports when exporting in System.register format.
+  if (mergedConfig.output.libraryTarget === 'system' || mergedConfig.output.libraryTarget === 'module') {
+    // Don't used named exports when exporting in System.register or ES Module format.
     delete mergedConfig.output.library;
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

Currently, setting `"libraryTarget": "module"` emits the following error:

>  Error: Library name must be unset. Common configuration options that specific library names are 'output.library[.name]', 'entry.xyz.library[.name]', 'ModuleFederationPlugin.name' and 'ModuleFederationPlugin.library[.name]'.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

The error is no longer emitted.

## Does this PR introduce a breaking change?

- [x] No

